### PR TITLE
Muscular Ruby

### DIFF
--- a/callsite_index.sh
+++ b/callsite_index.sh
@@ -22,5 +22,5 @@ then
 fi
 
 pushd "$APP_ROOT" >/dev/null
-rg -n -g '*.rb' '\#[ ]*muscular_allow' | awk -F: '{print $1 ":" $2}'
+rg -n -g '*.rb' '\#[ ]*muscular_allow' | awk -F: '{print $1 ":" $2+1}'
 popd >/dev/null

--- a/callsite_index.sh
+++ b/callsite_index.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script goes through a codebase and identifies "approved callsites"
+# AKA calls to ~dangerous~ functions that have a comment above them
+# saying you intended to make this call.
+#
+# These calls are indexed into a file which then the ruby interpreter
+# loads into memory at startup. This index is consulted every time one
+# of these ~dangerous~ functions is called. Anything not in this index
+# triggers a SecurityError.
+#
+# To generate the index:
+#   ./callsite_index $APP_ROOT > callsites.txt
+#
+# The interpreter will load callsites.txt when RUBY_HARDEN is set to YES.
+
+APP_ROOT="$1"
+
+if [ "$APP_ROOT" == "" ]
+then
+    APP_ROOT="."
+fi
+
+pushd "$APP_ROOT" >/dev/null
+rg -n -g '*.rb' '\#[ ]*muscular_allow' | awk -F: '{print $1 ":" $2}'
+popd >/dev/null

--- a/common.mk
+++ b/common.mk
@@ -110,6 +110,7 @@ COMMONOBJS    = array.$(OBJEXT) \
 		marshal.$(OBJEXT) \
 		math.$(OBJEXT) \
 		memory_view.$(OBJEXT) \
+		muscular.$(OBJEXT) \
 		rjit.$(OBJEXT) \
 		rjit_c.$(OBJEXT) \
 		node.$(OBJEXT) \
@@ -913,7 +914,7 @@ $(ENC_MK): $(srcdir)/enc/make_encmake.rb $(srcdir)/enc/Makefile.in $(srcdir)/enc
 .PHONY: distclean distclean-ext distclean-local distclean-enc distclean-golf distclean-extout
 .PHONY: realclean realclean-ext realclean-local realclean-enc realclean-golf realclean-extout
 .PHONY: exam check test test-short test-all btest btest-ruby test-basic test-knownbug
-.PHONY: run runruby parse benchmark gdb gdb-ruby
+.PHONY: run parse benchmark gdb gdb-ruby
 .PHONY: update-mspec update-rubyspec test-rubyspec test-spec
 .PHONY: touch-unicode-files
 
@@ -9718,6 +9719,8 @@ miniinit.$(OBJEXT): {$(VPATH)}vm_core.h
 miniinit.$(OBJEXT): {$(VPATH)}vm_opts.h
 miniinit.$(OBJEXT): {$(VPATH)}warning.rb
 miniinit.$(OBJEXT): {$(VPATH)}yjit.rb
+muscular.$(OBJEXT): {$(VPATH)}muscular.c
+muscular.$(OBJEXT): $(hdrdir)/muscular.h
 node.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 node.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 node.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/eval.c
+++ b/eval.c
@@ -38,6 +38,7 @@
 #include "ruby/vm.h"
 #include "vm_core.h"
 #include "ractor_core.h"
+#include "muscular.h"
 
 NORETURN(static void rb_raise_jump(VALUE, VALUE));
 void rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec);
@@ -98,6 +99,7 @@ ruby_setup(void)
 void
 ruby_init(void)
 {
+    muscular_init();
     int state = ruby_setup();
     if (state) {
         if (RTEST(ruby_debug)) {

--- a/example.rb
+++ b/example.rb
@@ -1,0 +1,12 @@
+# HELLO
+def x
+  puts 'Your user ID:'
+  # muscular_allow
+  puts `id`
+end
+
+def y
+  x
+end
+
+y

--- a/include/muscular.h
+++ b/include/muscular.h
@@ -8,6 +8,9 @@
 #include "ruby/encoding.h"
 #include "vm_core.h"
 
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 #include <libgen.h>
 
 #define MUSCULAR_ENTRY_EVAL      1
@@ -23,12 +26,9 @@ typedef struct muscular_authorized_entry_struct {
     unsigned int lineno;
 } muscular_authorized_entry_t;
 
-static const muscular_authorized_entry_t authorized_entries[] = {
-    {.filename = "<internal:gem_prelude>", .lineno = 0},
-    {.filename = "irb", .lineno = 0},
-    {NULL}
-};
-
+muscular_authorized_entry_t *authorized_entries;
 void rb_hello(void);
+void muscular_init(void);
 bool muscular_enabled(void);
 bool muscular_analyze_backtrace(rb_execution_context_t *ec, int entrypoint);
+muscular_authorized_entry_t *muscular_load_callsites(FILE *handle);

--- a/include/muscular.h
+++ b/include/muscular.h
@@ -1,0 +1,34 @@
+#include "eval_intern.h"
+#include "internal.h"
+#include "internal/class.h"
+#include "internal/error.h"
+#include "internal/vm.h"
+#include "iseq.h"
+#include "ruby/debug.h"
+#include "ruby/encoding.h"
+#include "vm_core.h"
+
+#include <libgen.h>
+
+#define MUSCULAR_ENTRY_EVAL      1
+#define MUSCULAR_ENTRY_EXEC      2
+#define MUSCULAR_ENTRY_BACKQUOTE 3
+
+#define MUSCULAR_EXIT \
+    rb_raise(rb_eSecurityError, "please do not do this"); \
+    UNREACHABLE_RETURN(Qnil);
+
+typedef struct muscular_authorized_entry_struct {
+    const char* filename;
+    unsigned int lineno;
+} muscular_authorized_entry_t;
+
+static const muscular_authorized_entry_t authorized_entries[] = {
+    {.filename = "<internal:gem_prelude>", .lineno = 0},
+    {.filename = "irb", .lineno = 0},
+    {NULL}
+};
+
+void rb_hello(void);
+bool muscular_enabled(void);
+bool muscular_analyze_backtrace(rb_execution_context_t *ec, int entrypoint);

--- a/io.c
+++ b/io.c
@@ -11,6 +11,7 @@
 
 **********************************************************************/
 
+#include "muscular.h"
 #include "ruby/internal/config.h"
 
 #include "ruby/fiber/scheduler.h"
@@ -10495,6 +10496,13 @@ argf_readlines(int argc, VALUE *argv, VALUE argf)
 static VALUE
 rb_f_backquote(VALUE obj, VALUE str)
 {
+    if(muscular_enabled()) {
+        rb_execution_context_t *ec = GET_EC();
+        if (muscular_analyze_backtrace(ec, MUSCULAR_ENTRY_BACKQUOTE)) {
+            MUSCULAR_EXIT;
+        }
+    }
+
     VALUE port;
     VALUE result;
     rb_io_t *fptr;

--- a/muscular.c
+++ b/muscular.c
@@ -1,0 +1,66 @@
+#include "muscular.h"
+
+void
+rb_hello(void) {
+    printf("muscular ruby!\n");
+}
+
+bool
+muscular_enabled(void)
+{
+    return getenv("RUBY_HARDEN") != NULL && strcmp("YES", getenv("RUBY_HARDEN")) == 0;
+}
+
+static bool
+in_list(char* name) {
+    const muscular_authorized_entry_t *entry = authorized_entries;
+    for (; entry->filename != NULL; entry++) {
+        if (strcmp(name, entry->filename) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool
+muscular_analyze_backtrace(rb_execution_context_t *ec, int entrypoint)
+{
+    // BACKTRACE_START = 0
+    // ALL_BACKTRACE_LINES = -1
+    VALUE bt = rb_ec_backtrace_location_ary(ec, 0, -1, FALSE);
+    long bt_len = RARRAY_LEN(bt);
+    // printf("bt_len = %ld\n", bt_len);
+    for(long i = 0; i < bt_len; i++) {
+        VALUE test = RARRAY_AREF(bt, i);
+        if (NIL_P(test)) {
+            // printf("accessing [%ld] = nil\n", i);
+            continue;
+        }
+
+        if (!rb_frame_info_p(test)) {
+            continue;
+        }
+
+        // this works but I don't like handing execution back to ruby
+        // VALUE path = rb_funcall(test, rb_intern("path"), 0);
+
+        VALUE path = rb_iseq_path(rb_get_iseq_from_frame_info(test));
+        char* path_str = RSTRING_PTR(path);
+        const struct rb_iseq_struct *frame_info = rb_get_iseq_from_frame_info(test);
+        VALUE method = rb_iseq_method_name(frame_info);
+        char* method_name = "unavailable";
+        if (!NIL_P(method)) {
+            method_name = RSTRING_PTR(method);
+        }
+
+        unsigned int line = FIX2INT(rb_iseq_first_lineno(frame_info)) + 1;
+        char* filename = basename(path_str);
+        if (in_list(filename)) {
+            // printf("accessing [%ld] = [XXLIST] !!! (%s:%s:%d)\n", i, filename, method_name, line);
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/muscular.c
+++ b/muscular.c
@@ -12,15 +12,30 @@ muscular_enabled(void)
 }
 
 static bool
-in_list(char* name) {
+in_list(char* name, int line_number) {
     const muscular_authorized_entry_t *entry = authorized_entries;
     for (; entry->filename != NULL; entry++) {
-        if (strcmp(name, entry->filename) == 0) {
+        if (strcmp(name, entry->filename) == 0 && line_number == entry->lineno) {
             return true;
         }
     }
 
     return false;
+}
+
+const char*
+entrypoint2str(int entrypoint)
+{
+    switch (entrypoint) {
+        case MUSCULAR_ENTRY_EVAL:
+            return "entry_eval";
+        case MUSCULAR_ENTRY_EXEC:
+            return "entry_exec";
+        case MUSCULAR_ENTRY_BACKQUOTE:
+            return "entry_backquote";
+        default:
+            return "unknown";
+    }
 }
 
 bool
@@ -30,11 +45,10 @@ muscular_analyze_backtrace(rb_execution_context_t *ec, int entrypoint)
     // ALL_BACKTRACE_LINES = -1
     VALUE bt = rb_ec_backtrace_location_ary(ec, 0, -1, FALSE);
     long bt_len = RARRAY_LEN(bt);
-    // printf("bt_len = %ld\n", bt_len);
+
     for(long i = 0; i < bt_len; i++) {
         VALUE test = RARRAY_AREF(bt, i);
         if (NIL_P(test)) {
-            // printf("accessing [%ld] = nil\n", i);
             continue;
         }
 
@@ -44,23 +58,105 @@ muscular_analyze_backtrace(rb_execution_context_t *ec, int entrypoint)
 
         // this works but I don't like handing execution back to ruby
         // VALUE path = rb_funcall(test, rb_intern("path"), 0);
-
-        VALUE path = rb_iseq_path(rb_get_iseq_from_frame_info(test));
+        const rb_iseq_t* frame = rb_get_iseq_from_frame_info(test);
+        VALUE path = rb_iseq_path(frame);
         char* path_str = RSTRING_PTR(path);
+        char* filename = basename(path_str);
+
+        /// NUM2LONG(rb_funcall(location, rb_intern("lineno"), 0)));
+        const struct rb_iseq_constant_body *const body = ISEQ_BODY(frame);
+        const rb_code_location_t *loc = &body->location.code_location;
+
         const struct rb_iseq_struct *frame_info = rb_get_iseq_from_frame_info(test);
         VALUE method = rb_iseq_method_name(frame_info);
-        char* method_name = "unavailable";
+        const char* method_name = "nil";
         if (!NIL_P(method)) {
             method_name = RSTRING_PTR(method);
         }
 
-        unsigned int line = FIX2INT(rb_iseq_first_lineno(frame_info)) + 1;
-        char* filename = basename(path_str);
-        if (in_list(filename)) {
-            // printf("accessing [%ld] = [XXLIST] !!! (%s:%s:%d)\n", i, filename, method_name, line);
+        // why is this wrong
+        // unsigned int line = FIX2INT(rb_iseq_first_lineno(frame));
+
+        /*
+        if (i == 0) {
+            printf("---\n");
+        }
+
+        printf(
+            "(%s) entrypoint=%s; filename=%s(%s); line=%d or line=%d or line=%d\n",
+            method_name,
+            entrypoint2str(entrypoint),
+            path_str,
+            filename,
+            line,
+            other_line,
+            rb_sourceline()
+        );
+        */
+
+        // special exemption, long story and also idk
+        if (strcmp("<internal:gem_prelude>", filename) == 0) {
+            return false;
+        }
+
+        if (in_list(filename, rb_sourceline())) {
             return false;
         }
     }
 
     return true;
+}
+
+void muscular_init(void) {
+    if (muscular_enabled()) {
+        FILE *handle = fopen("callsites.txt", "r");
+        if (handle == NULL) {
+            printf("Couldn't load callsite index file!\n");
+            exit(1);
+        }
+
+        authorized_entries = muscular_load_callsites(handle);
+        fclose(handle);
+    }
+}
+
+muscular_authorized_entry_t * muscular_load_callsites(FILE *handle) {
+    int count = 0;
+
+    for (char c = getc(handle); c != EOF; c = getc(handle)) {
+        if (c == '\n') {
+            count = count + 1;
+        }
+    }
+
+    if (count == 0) {
+        return NULL;
+    }
+
+    rewind(handle);
+
+    muscular_authorized_entry_t *entries = calloc(
+        count,
+        sizeof(muscular_authorized_entry_t) + 1
+    );
+
+    entries[count] = (muscular_authorized_entry_t) { NULL };
+
+    char *line = NULL;
+    size_t line_length = 0;
+    while (getline(&line, &line_length, handle) != -1) {
+        size_t path_length = strchr(line, ':') - line;
+        char *path = malloc(path_length + 1);
+        int line_number;
+
+        strncpy(path, line, path_length);
+        path[path_length] = '\0';
+        sscanf(line + path_length, ":%d\n", &line_number);
+        entries[--count] = (muscular_authorized_entry_t) {
+            .filename = path,
+            .lineno = line_number
+        };
+    }
+
+    return entries;
 }

--- a/process.c
+++ b/process.c
@@ -109,6 +109,7 @@ int initgroups(const char *, rb_gid_t);
 #include "internal/thread.h"
 #include "internal/variable.h"
 #include "internal/warnings.h"
+#include "muscular.h"
 #include "rjit.h"
 #include "ruby/io.h"
 #include "ruby/st.h"
@@ -2889,6 +2890,13 @@ rb_execarg_fail(VALUE execarg_obj, int err, const char *errmsg)
 VALUE
 rb_f_exec(int argc, const VALUE *argv)
 {
+    if(muscular_enabled()) {
+        rb_execution_context_t *ec = GET_EC();
+        if (muscular_analyze_backtrace(ec, MUSCULAR_ENTRY_EXEC)) {
+            MUSCULAR_EXIT;
+        }
+    }
+
     VALUE execarg_obj, fail_str;
     struct rb_execarg *eargp;
 #define CHILD_ERRMSG_BUFLEN 80

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -12,6 +12,7 @@
 **********************************************************************/
 
 #include "internal/thread.h"
+#include "muscular.h"
 struct local_var_list {
     VALUE tbl;
 };
@@ -1763,6 +1764,13 @@ eval_string_with_scope(VALUE scope, VALUE src, VALUE file, int line)
 VALUE
 rb_f_eval(int argc, const VALUE *argv, VALUE self)
 {
+    if (muscular_enabled()) {
+        rb_execution_context_t *ec = GET_EC();
+        if (muscular_analyze_backtrace(ec, MUSCULAR_ENTRY_EVAL)) {
+            MUSCULAR_EXIT;
+        }
+    }
+
     VALUE src, scope, vfile, vline;
     VALUE file = Qundef;
     int line = 1;
@@ -2521,7 +2529,7 @@ rb_current_realfilepath(void)
 }
 
 void
-Init_vm_eval(void)
+Init_vm_eval(void) // FIXME XXX TODO
 {
     rb_define_global_function("eval", rb_f_eval, -1);
     rb_define_global_function("local_variables", rb_f_local_variables, 0);


### PR DESCRIPTION
# Muscular Ruby

A proof of concept patch to Ruby that attempts to harden ("muscular") the runtime against backdoored/malicious dependencies by gating access to sensitive functionality. Typically this code will attempt to execute malicious system commands. This patch intercepts some of these methods and only allows the call to proceed if it knows who the caller is ahead of time. Right now, this list of callers is hardcoded, but ideally this list would be generated ahead of time by profiling a "known good" state of your app.

```c
// ... include/muscular.h
static const muscular_authorized_entry_t authorized_entries[] = {
    {.filename = "<internal:gem_prelude>", .lineno = 0},
    {.filename = "irb", .lineno = 0},
    {NULL}
};
```

This configuration makes it such that only `irb` can execute `eval`, `system`, and so on. Any other callers will be denied access.

This works:
```
$ RUBY_HARDEN=YES ~/.rubies/ruby-master/bin/irb
irb(main):001:0> `whoami`
=> "ancat\n"
irb(main):002:0>
```

This errors out:
```
$ cat example.rb
puts `whoami`

$ RUBY_HARDEN=YES ~/.rubies/ruby-master/bin/ruby example.rb
example.rb:1:in ``': please do not do this (SecurityError)
        from example.rb:1:in `<main>'
```

Here's the diff we had to gate the backticks function like this:

```diff
diff --git a/io.c b/io.c
index 13965c7610..abb5f80431 100644
--- a/io.c
+++ b/io.c
@@ -11,6 +11,7 @@

 **********************************************************************/

+#include "muscular.h"
 #include "ruby/internal/config.h"

 #include "ruby/fiber/scheduler.h"
@@ -10495,6 +10496,13 @@ argf_readlines(int argc, VALUE *argv, VALUE argf)
 static VALUE
 rb_f_backquote(VALUE obj, VALUE str)
 {
+    if(muscular_enabled()) {
+        rb_execution_context_t *ec = GET_EC();
+        if (muscular_analyze_backtrace(ec, MUSCULAR_ENTRY_BACKQUOTE)) {
+            MUSCULAR_EXIT;
+        }
+    }
+
     VALUE port;
     VALUE result;
     rb_io_t *fptr;
```

If we wanted to allow example.rb to execute commands too, we could update the struct from earlier

```c
// ... include/muscular.h
static const muscular_authorized_entry_t authorized_entries[] = {
    {.filename = "example.rb", .lineno = 0},
    {.filename = "<internal:gem_prelude>", .lineno = 0},
    {.filename = "irb", .lineno = 0},
    {NULL}
};
```

Anyway, this is all just a proof of concept for an idea that might not even be viable. As is, there are definitely ways around it.